### PR TITLE
[Feat-1] 예외 전략 코드 추가

### DIFF
--- a/src/main/java/payroad/global/response/ApiResponse.java
+++ b/src/main/java/payroad/global/response/ApiResponse.java
@@ -1,0 +1,24 @@
+package payroad.global.response;
+
+import payroad.global.response.status.ErrorStatus;
+import payroad.global.response.status.SuccessStatus;
+
+public record ApiResponse<T>(
+        Boolean isSuccess,
+        String code,
+        String message,
+        T result) {
+
+    public static final ApiResponse<Void> OK = new ApiResponse<>(true, SuccessStatus.OK.getCode(),
+            SuccessStatus.OK.getMessage(), null);
+
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(true, SuccessStatus.OK.getCode(), SuccessStatus.OK.getMessage(),
+                result);
+    }
+
+    public static <T> ApiResponse<T> onFailure(ErrorStatus errorStatus, T data) {
+        return new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), data);
+    }
+
+}

--- a/src/main/java/payroad/global/response/exception/GeneralException.java
+++ b/src/main/java/payroad/global/response/exception/GeneralException.java
@@ -1,0 +1,35 @@
+package payroad.global.response.exception;
+
+import payroad.global.response.status.ErrorStatus;
+import lombok.Getter;
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private final ErrorStatus errorStatus;
+    private final Object data;
+
+    public GeneralException(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+        this.data = null;
+    }
+
+    public GeneralException(ErrorStatus errorStatus, Object data) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+        this.data = data;
+    }
+
+    public GeneralException(ErrorStatus errorStatus, Throwable cause) {
+        super(errorStatus.getMessage(), cause);
+        this.errorStatus = errorStatus;
+        this.data = null;
+    }
+
+    public GeneralException(ErrorStatus errorStatus, Object data, Throwable cause) {
+        super(errorStatus.getMessage(), cause);
+        this.errorStatus = errorStatus;
+        this.data = data;
+    }
+}

--- a/src/main/java/payroad/global/response/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/payroad/global/response/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,84 @@
+package payroad.global.response.exception.handler;
+
+import payroad.global.response.ApiResponse;
+import payroad.global.response.exception.GeneralException;
+import payroad.global.response.status.ErrorStatus;
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Object>> handleGeneralException(GeneralException ex) {
+        log.error("Error Code: {}, Message: {}, Data: {}",
+                ex.getErrorStatus().getCode(),
+                ex.getErrorStatus().getMessage(),
+                ex.getData() != null ? ex.getData() : "No additional data",
+                ex
+        );
+
+        return ResponseEntity
+                .status(ex.getErrorStatus().getHttpStatus())
+                .body(ApiResponse.onFailure(
+                        ex.getErrorStatus(),
+                        ex.getData()
+                ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException ex
+    ) {
+        List<String> errorMessages = getValidationErrorMessages(ex);
+        log.error("Validation errors: {}", errorMessages, ex);
+
+        return ResponseEntity
+                .status(ErrorStatus.BAD_REQUEST.getHttpStatus())
+                .body(ApiResponse.onFailure(
+                        ErrorStatus.BAD_REQUEST,
+                        errorMessages
+                ));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Object>> handleConstraintViolationException(
+            ConstraintViolationException ex
+    ) {
+        List<String> errorMessages = getValidationErrorMessages(ex);
+        log.error("Validation errors: {}", errorMessages, ex);
+
+        return ResponseEntity
+                .status(ErrorStatus.BAD_REQUEST.getHttpStatus())
+                .body(ApiResponse.onFailure(
+                        ErrorStatus.BAD_REQUEST,
+                        errorMessages
+                ));
+    }
+
+    private List<String> getValidationErrorMessages(MethodArgumentNotValidException ex) {
+        return ex.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> {
+                    String field = fieldError.getField();       // 실패한 필드 이름
+                    String message = fieldError.getDefaultMessage(); // 검증 실패 메시지
+                    return field + ": " + message;
+                })
+                .toList();
+    }
+
+    private List<String> getValidationErrorMessages(ConstraintViolationException ex) {
+        return ex.getConstraintViolations().stream()
+                .map(violation -> {
+                    String field = violation.getPropertyPath().toString(); // 위반된 필드
+                    String message = violation.getMessage();              // 검증 실패 메시지
+                    return field + ": " + message;
+                })
+                .toList();
+    }
+}

--- a/src/main/java/payroad/global/response/status/ErrorStatus.java
+++ b/src/main/java/payroad/global/response/status/ErrorStatus.java
@@ -1,0 +1,22 @@
+package payroad.global.response.status;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorStatus {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "로그인 인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+
+    ;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/payroad/global/response/status/SuccessStatus.java
+++ b/src/main/java/payroad/global/response/status/SuccessStatus.java
@@ -1,0 +1,17 @@
+package payroad.global.response.status;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessStatus {
+
+    OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}


### PR DESCRIPTION
## #️⃣ 요약 설명

### GlobalExceptionHandler, GeneralException, Status만 이용해서 예외전략 코드를 추가했습니다.

## 📝 작업 내용

> 

### 📜 ApiResponse Class

**ApiResponse 클래스 정의**

```java
public record ApiResponse<T>(
        Boolean isSuccess,
        String code,
        String message,
        T result) {
...
```

* **Record 타입**: 이 클래스는 Java 14의 **Record** 타입으로 정의되었습니다. Record는 **불변 데이터 클래스**로 주로 데이터 전송 객체(DTO)를
  단순하게 생성할 때 사용됩니다.
* **Generics 사용 (****<T>****)**: 응답이 다양한 데이터 타입을 가질 수 있도록 제네릭 타입 매개변수 T를 사용하고 있습니다.
* **필드 설명**:
    * `Boolean isSuccess`: 요청의 성공 여부를 나타냅니다.
    * `String code`: 응답 상태를 나타내는 코드입니다. 응답 코드를 담습니다.
    * `String message`: 응답에 대한 메시지입니다. 주로 응답에 대한 설명을 저장합니다.
    * `T result`: 응답의 결과 데이터를 포함합니다. 결과는 제네릭 타입으로 지정되어 있어 다양한 유형의 데이터를 담을 수 있습니다.

**상수 및 메서드**

```java
public static final ApiResponse<Void> OK = new ApiResponse<>(true, SuccessStatus.OK.getCode(),
        SuccessStatus.OK.getMessage(), null);

```

* **OK** **상수**: OK는 성공적인 응답을 나타내는 **정적 상수**로, 아무런 결과 데이터(result)가 없을 때 사용됩니다.
    * 성공 시, 전달하고 싶은 데이터가 없을 때 Controller에서 `return ApiResponse.OK` 작성합니다.

```java
public static <T> ApiResponse<T> onSuccess(T result) {
    return new ApiResponse<>(true, SuccessStatus.OK.getCode(), SuccessStatus.OK.getMessage(),
            result);
}

```

* **onSuccess** **메서드**: 성공적인 응답을 생성하기 위한 **정적 팩토리 메서드**입니다.
    * **매개변수**: 성공적인 결과 데이터 (result).
    * **반환 값**: isSuccess가 true이고, 상태 코드는 성공 상태 (SuccessStatus.OK)인 ApiResponse 객체를 반환합니다.

```java
public static <T> ApiResponse<T> onFailure(ErrorStatus errorStatus, T data) {
    return new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), data);
}

```

* **onFailure** **메서드**: 오류 응답을 생성하기 위한 **정적 팩토리 메서드**입니다.
    * **매개변수**: 오류 상태 (errorStatus)와 추가적인 결과 데이터 (data).
    * **반환 값**: isSuccess가 false이고, 오류 상태 코드 및 메시지를 가지는 ApiResponse 객체를 반환합니다.
    * 보통 ExceptionHandler에서 사용하게 될 메서드 입니다.

### 📜 ErrorStatus Class

⠀

```java

@Getter
@RequiredArgsConstructor
public enum ErrorStatus {
    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),

...

    private final HttpStatus httpStatus;
    private final String code;
    private final String message;

}

```

- ErrorStatus 클래스는 애플리케이션의 오류 상태를 관리하기 위한 **열거형(enum)**입니다.

* **필드**
    * `HttpStatus httpStatus`: HTTP 상태 코드를 나타냅니다. 새로 생성할 시, 컨벤션에 맞춰 400으로 통일합니다.
    * `String code`: 커스텀 오류 코드를 정의합니다.
    * `String message`: 사용자에게 표시할 오류 메시지입니다.

- **사용법**
    - 비즈니스적 오류가 발생하여 런타임 예외를 개발자가 발생시키고 싶거나, 체크 예외를 catch해서 런타임예외로 바꾸고 싶다면 ErrorStatus 클래스 내에 새로운
      데이터를 정의하고 이를 GeneralException 클래스에 담아서 throw 합니다.

### 📜 GeneralException Class

```java

@Getter
public class GeneralException extends RuntimeException {

    private final ErrorStatus errorStatus;
    private final Object data;

    public GeneralException(ErrorStatus errorStatus) {
        super(errorStatus.getMessage());
        this.errorStatus = errorStatus;
        this.data = null;
    }

    public GeneralException(ErrorStatus errorStatus, Object data) {
        super(errorStatus.getMessage());
        this.errorStatus = errorStatus;
        this.data = data;
    }

    public GeneralException(ErrorStatus errorStatus, Throwable cause) {
        super(errorStatus.getMessage(), cause);
        this.errorStatus = errorStatus;
        this.data = null;
    }

    public GeneralException(ErrorStatus errorStatus, Object data, Throwable cause) {
        super(errorStatus.getMessage(), cause);
        this.errorStatus = errorStatus;
        this.data = data;
    }
}


```

- GeneralException 클래스는 애플리케이션에서 발생할 수 있는 예외를 처리하기 위해 정의된 **사용자 정의 예외 클래스**입니다. 이 클래스는 **런타임 예외 (
  RuntimeException)**를 상속받아, 런타임에서 발생하는 오류를 다룹니다. 클래스 구성은 다음과 같습니다:

**필드**

```java
private final ErrorStatus errorStatus;
private final Object data;
```

* `ErrorStatus errorStatus`: 발생한 오류의 상태를 나타내는 **ErrorStatus** 객체입니다.
* `Object data`: 예외 발생 시 추가적인 정보를 전달할 수 있는 데이터입니다.

**생성자**

```java
public GeneralException(ErrorStatus errorStatus) {
    super(errorStatus.getMessage());
    this.errorStatus = errorStatus;
    this.data = null;
}

public GeneralException(ErrorStatus errorStatus, Object data) {
    super(errorStatus.getMessage());
    this.errorStatus = errorStatus;
    this.data = data;
}

public GeneralException(ErrorStatus errorStatus, Throwable cause) {
    super(errorStatus.getMessage(), cause);
    this.errorStatus = errorStatus;
    this.data = null;
}

public GeneralException(ErrorStatus errorStatus, Object data, Throwable cause) {
    super(errorStatus.getMessage(), cause);
    this.errorStatus = errorStatus;
    this.data = data;
}


```

* **첫 번째 생성자**: ErrorStatus만 받아서 예외를 생성하며, 추가 데이터는 null로 설정합니다.
* **두 번째 생성자**: ErrorStatus와 함께 추가 데이터를 받아 예외를 생성합니다.
* **세 번째 생성자**: ErrorStatus와 **발생 원인 (cause)**을 받아 예외를 생성합니다. 예외 발생 원인을 포함하여 추적이 가능하도록 합니다.
* **네 번째 생성자**: ErrorStatus, 에러 데이터 (data), 그리고 발생 원인 (cause)를 모두 받아 예외를 생성합니다.

### 사용 예시

**단순한 오류 상태만 사용하여 예외 생성**

```java
throw new GeneralException(ErrorStatus.BAD_REQUEST);
```

**추가 데이터와 함께 예외 생성**

```java
throw new GeneralException(ErrorStatus.MEMBER_MAJOR_NOT_FOUND, this);
```

- 비즈니스적 에러가 발생 시 해당 방식을 권장합니다.

**발생 원인 (****cause****)과 함께 예외 생성**

```java
try{
        ...
        }catch(Exception e){
        throw new

GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR, e);
}

```

- **발생 원인**을 포함하여 GeneralException을 던져 예외 추적이 가능합니다.
- 체크 예외를 언체크 예외로 전환할 때, **반드시 예외를 포함해서 던지도록 합니다.**

**발생 원인 (cause), 데이터와 함께 예외 생성**

```java
try{
        ...
        }catch(Exception e){
        throw new

GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR, this,e);
}

```

⠀

## 📜 GlobalExceptionHandler

```java

@Slf4j
@RestControllerAdvice
public class GlobalExceptionHandler {

    @ExceptionHandler(GeneralException.class)
    public ResponseEntity<ApiResponse<Object>> handleGeneralException(GeneralException ex) {
        log.error("Error Code: {}, Message: {}, Data: {}",
                ex.getErrorStatus().getCode(),
                ex.getErrorStatus().getMessage(),
                ex.getData() != null ? ex.getData() : "No additional data",
                ex
        );

        return ResponseEntity
                .status(ex.getErrorStatus().getHttpStatus())
                .body(ApiResponse.onFailure(
                        ex.getErrorStatus(),
                        ex.getData()
                ));
    }
}

```

- **로깅**
    * Error Code: 예외의 상태 코드 (ErrorStatus에 정의된 코드).
    * Message: 예외의 메시지.
    * Data: 추가적인 오류 데이터, 없을 경우 "No additional data"로 표시.
    * ex: **스택 트레이스**가 함께 기록되어 예외 발생 경로와 원인까지 확인할 수 있습니다.

- **응답생성**
    - 예외의 상태 코드를 사용하여 HTTP 응답 상태를 설정합니다. 저희 프로젝트 컨벤션에 맞춰 `ErrorStatus`를 400으로 생성하면, 항상 상태코드는 400으로
      클라이언트에게 전달됩니다.
    - `ApiResponse.onFailure()`: 오류 응답을 생성하는 정적 메서드를 사용하여, 실패 상태의 응답 객체를 생성합니다.

- 추후 메소드 추가 가능성
    - GeneralException 이외에도, Spring에서 정의한 예외를 잡기 위해, 해당 GlobalExceptionHandler 내에서 메소드를 추가하여 처리하도록
      확장할 수 있습니다.

---

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
